### PR TITLE
Issue-1285: Upgrade to Jackson 2.9.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,46 @@
-.metadata
-target
+# common ignore
+*~
+MANIFEST.MF
+target/
+tmp/
+*.versionsBackup
+.m2/
+
+# Java Files #
+*.jar
+*.war
+*.class
+
+# eclipse specific
 .settings
 .project
 .classpath
-.springBeans
-.pydevproject
-.recommenders
-node_modules
-dist
-.idea/
-Servers
+.metadata
+.factorypath
 
+# idea specific
+.idea/*
+!.idea/codeStyleSettings.xml
+*.iml
+*.ipr
+*.iws
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# unix specific
+.DS_Store
+.directory
+
+# static plugins
+.pmd
+
+# log files
+logs/
+*.log
+
+lib/*
+!strongbox-security/strongbox-authentication-registry/src/test/resources/webapp/WEB-INF/lib/strongbox-example-authentication-provider-1.0-SNAPSHOT.jar
+!strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/resources/artifacts/properties-injector-1.7.jar
+*.sh
+.idea

--- a/strongbox-npm-metadata-parent/pom.xml
+++ b/strongbox-npm-metadata-parent/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
         <groovy.version>2.4.7</groovy.version>
     </properties>
 


### PR DESCRIPTION
Fixes strongbox/strongbox#1285.

Tasks carried out:
* [x] Update the version of the Jackson dependencies in the [`strongbox-npm-metadata`](https://github.com/strongbox/strongbox-npm-metadata/) project.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.